### PR TITLE
Add missing dependency to joint_effort_trajectory_controller

### DIFF
--- a/joint_effort_trajectory_controller/package.xml
+++ b/joint_effort_trajectory_controller/package.xml
@@ -22,6 +22,7 @@
 
     <depend>controller_interface</depend>
     <depend>control_msgs</depend>
+    <depend>control_toolbox</depend>
     <depend>hardware_interface</depend>
     <depend>rclcpp</depend>
     <depend>rclcpp_lifecycle</depend>


### PR DESCRIPTION
It's being used in https://github.com/frankaemika/franka_ros2/blob/develop/joint_effort_trajectory_controller/CMakeLists.txt#L23