### PR TITLE
fix libfranka linking

### DIFF
--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(franka_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(Franka REQUIRED)
 find_package(franka_semantic_components)
 find_package(generate_parameter_library)
 
@@ -51,7 +52,7 @@ ament_target_dependencies(
 
 generate_parameter_library(franka_example_controllers_parameters src/model_example_controller_parameters.yaml)
 
-target_link_libraries(${PROJECT_NAME} franka_example_controllers_parameters)
+target_link_libraries(${PROJECT_NAME} franka_example_controllers_parameters Franka::Franka)
 
 pluginlib_export_plugin_description_file(
         controller_interface franka_example_controllers.xml)

--- a/franka_robot_state_broadcaster/CMakeLists.txt
+++ b/franka_robot_state_broadcaster/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     control_msgs
     controller_interface
     controller_manager
+    Franka
     franka_msgs
     franka_semantic_components
     generate_parameter_library
@@ -47,7 +48,7 @@ target_include_directories(
 generate_parameter_library(franka_robot_state_broadcaster_parameters src/franka_robot_state_broadcaster_parameters.yaml)
 
 target_link_libraries(franka_robot_state_broadcaster
-                      PUBLIC franka_robot_state_broadcaster_parameters)
+                      PUBLIC franka_robot_state_broadcaster_parameters Franka::Franka)
 ament_target_dependencies(franka_robot_state_broadcaster PUBLIC
                           ${THIS_PACKAGE_INCLUDE_DEPENDS})
 


### PR DESCRIPTION
Compiling the targets `franka_example_controllers_parameters` and `franka_robot_state_broadcaster_parameters` fails due to the missing linking to libfranka. This PR fixes the issue by linking the libfranka target `Franka::Franka`. This also makes sure that the include paths or correctly imported.