### PR TITLE
Fix Test the Setup command in README: corrected package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The `franka_ros2` package includes a `.devcontainer` folder, which allows you to
 To verify that your setup works correctly without a robot, you can run the following command to use dummy hardware:
 
 ```bash
-ros2 launch franka_moveit_config moveit.launch.py robot_ip:=dont-care use_fake_hardware:=true
+ros2 launch franka_fr3_moveit_config moveit.launch.py robot_ip:=dont-care use_fake_hardware:=true
 ```
 
 


### PR DESCRIPTION
### Summary
This PR fixes the command under the "Test the Setup" section in the README. 

- Corrected the package name in the command from `franka_moveit_config` to `franka_fr3_moveit_config`.
```diff
  - ros2 launch franka_moveit_config moveit.launch.py robot_ip:=dont-care use_fake_hardware:=true
  + ros2 launch franka_fr3_moveit_config moveit.launch.py robot_ip:=dont-care use_fake_hardware:=true
```
### Related Issue
Fixes [issue#82](https://github.com/frankaemika/franka_ros2/issues/82)

