### PR TITLE
Use robot_description topic for controller manager in franka.launch.py

### DIFF
--- a/franka_bringup/launch/franka.launch.py
+++ b/franka_bringup/launch/franka.launch.py
@@ -74,11 +74,11 @@ def robot_description_dependent_nodes_spawner(
             package='controller_manager',
             executable='ros2_control_node',
             parameters=[franka_controllers,
-                        {'robot_description': robot_description},
                         {'arm_id': arm_id},
                         {'load_gripper': load_gripper},
                         ],
-            remappings=[('joint_states', 'franka/joint_states')],
+            remappings=[('joint_states', 'franka/joint_states'),
+                        ('controller_manager/robot_description', 'robot_description')],
             output={
                 'stdout': 'screen',
                 'stderr': 'screen',


### PR DESCRIPTION
Since https://github.com/ros-controls/ros2_control/pull/940, passing a URDF file directly to the `controller_manager` is deprecated. Instead, the `robot_state_publisher` makes the robot description available on topic `/robot_description` and the controller manager should subscribe to that topic.

Every launch file now emits a warning:

```bash
[ros2_control_node-3] [WARN] [1741096056.232298456] [controller_manager]: [Deprecated] Passing the robot description parameter directly to the control_manager node is deprecated. Use '~/robot_description' topic from 'robot_state_publisher' instead.
```

This change removes this warning.

In ROS Humble, however, the controller manager subscribes to `~/robot description` (which resolves to `/controller_manager/robot_description`) by default, so a remap is also added to the controller manager to subscribe to `/robot_description` instead. This is not the case from Jazzy anymore (see https://github.com/ros-controls/ros2_control/pull/1410).

Node graph without the change (passing robot description by parameter):

![image](https://github.com/user-attachments/assets/78d242a9-0473-4e72-bb3c-0039feeb407c)

Node graph with the change (passing robot description with topic):

![image](https://github.com/user-attachments/assets/2d790f2f-4c31-4881-a987-83f9fb317f7e)
