### PR TITLE
Fix gripper config file

### DIFF
--- a/franka_gripper/config/franka_gripper_node.yaml
+++ b/franka_gripper/config/franka_gripper_node.yaml
@@ -1,6 +1,6 @@
-franka_gripper:
+/**:
   ros__parameters:
-    state_publish_rate: 50  # [Hz]
+    state_publish_rate: 15  # [Hz]
     feedback_publish_rate: 30 # [Hz]
     default_speed: 0.1  # [m/s]
     default_grasp_epsilon:

--- a/franka_gripper/launch/gripper.launch.py
+++ b/franka_gripper/launch/gripper.launch.py
@@ -77,14 +77,14 @@ def generate_launch_description():
             Node(
                 package='franka_gripper',
                 executable='franka_gripper_node',
-                name=[arm_id, '_gripper'],
+                name=['franka_gripper'],
                 parameters=[{'robot_ip': robot_ip, 'joint_names': joint_names}, gripper_config],
                 condition=UnlessCondition(use_fake_hardware),
             ),
             Node(
                 package='franka_gripper',
                 executable='fake_gripper_state_publisher.py',
-                name=[arm_id, '_gripper'],
+                name=['franka_gripper'],
                 parameters=[{'robot_ip': robot_ip, 'joint_names': joint_names}, gripper_config],
                 condition=IfCondition(use_fake_hardware),
             ),


### PR DESCRIPTION
Closes #121.
Closes #133.

I simply:
- Updated franka_gripper_node.yaml to accept any gripper name (it was set to franka_gripper but the gripper is called arm_id+gripper)
- Updated the state publish rate of the gripper config, since it can maximally publish at 15 Hz, not 50.
- Updated the name of the gripper in the gripper launch file from arm_id + "_gripper" to "franka_gripper". The `franka.launch.py` file expects the girpper to be called that way. 