### PR TITLE
franka_hardware: Add missing rclcpp_action and rclcpp_components dependencies in package.xml

### DIFF
--- a/franka_hardware/package.xml
+++ b/franka_hardware/package.xml
@@ -11,6 +11,7 @@
 
   <depend>libfranka</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>franka_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>

--- a/franka_hardware/package.xml
+++ b/franka_hardware/package.xml
@@ -12,6 +12,7 @@
   <depend>libfranka</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
   <depend>franka_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
The `rclcpp_action` dependency was added in the CMake in https://github.com/frankarobotics/franka_ros2/commit/4a001fc010c916858f56646fc007931647377478#diff-f4465f78e3e87470bb5d2b22df0aa00dcc3a48b8f63c24feac83b9ca1074a2f5, but the dependency was not added in the package.xml .

Similarly, the `rclcpp_components` dependency was added in https://github.com/frankarobotics/franka_ros2/commit/eae138a00d1c9346f2ee83437252affbf7d796ed#diff-f4465f78e3e87470bb5d2b22df0aa00dcc3a48b8f63c24feac83b9ca1074a2f5, but it was not added in package.xml .