### PR TITLE
Add controller_interface to package dependencies

### DIFF
--- a/franka_semantic_components/CMakeLists.txt
+++ b/franka_semantic_components/CMakeLists.txt
@@ -20,6 +20,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     geometry_msgs
     sensor_msgs
     hardware_interface
+    controller_interface
     rclcpp_lifecycle
     urdf)
 


### PR DESCRIPTION
Previously, `controller_interface` was only included in the `BUILD_TESTING` section, which caused build failures when compiling `franka_semantic_components` without running tests. Specifically, the compiler could not find the header `controller_interface/helpers.hpp` in `franka_semantic_component_interface.hpp`.

This PR moves controller_interface into `THIS_PACKAGE_INCLUDE_DEPENDS` so that it is properly found during normal builds. This ensures that `franka_semantic_components` can build independently of tests.