### PR TITLE
Fix: `move_group.launch.py` launch arguments

### DIFF
--- a/franka_fr3_moveit_config/launch/move_group.launch.py
+++ b/franka_fr3_moveit_config/launch/move_group.launch.py
@@ -63,11 +63,6 @@ def generate_launch_description():
         default_value='true',
         description='Whether to load the gripper or not (true or false)'
     )
-    load_gripper_arg = DeclareLaunchArgument(
-        load_gripper_parameter_name,
-        default_value='true',
-        description='Whether to load the gripper or not (true or false)'
-    )
     use_fake_hardware_arg = DeclareLaunchArgument(
         use_fake_hardware_parameter_name,
         default_value='false',

--- a/franka_fr3_moveit_config/launch/move_group.launch.py
+++ b/franka_fr3_moveit_config/launch/move_group.launch.py
@@ -53,6 +53,31 @@ def generate_launch_description():
     db_arg = DeclareLaunchArgument(
         'db', default_value='False', description='Database flag'
     )
+    namespace_arg = DeclareLaunchArgument(
+        namespace_parameter_name,
+        default_value='',
+        description='Namespace for the robot.'
+    )
+    load_gripper_arg = DeclareLaunchArgument(
+        load_gripper_parameter_name,
+        default_value='true',
+        description='Whether to load the gripper or not (true or false)'
+    )
+    load_gripper_arg = DeclareLaunchArgument(
+        load_gripper_parameter_name,
+        default_value='true',
+        description='Whether to load the gripper or not (true or false)'
+    )
+    use_fake_hardware_arg = DeclareLaunchArgument(
+        use_fake_hardware_parameter_name,
+        default_value='false',
+        description='Use fake hardware')
+    fake_sensor_commands_arg = DeclareLaunchArgument(
+        fake_sensor_commands_parameter_name,
+        default_value='false',
+        description="Fake sensor commands. Only valid when '{}' is true".format(
+            use_fake_hardware_parameter_name)
+    )
 
     franka_xacro_file = os.path.join(
         get_package_share_directory('franka_description'),
@@ -110,6 +135,10 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            namespace_arg,
+            load_gripper_arg,
+            use_fake_hardware_arg,
+            fake_sensor_commands_arg,
             db_arg,
             run_move_group_node,
         ]


### PR DESCRIPTION
## Description

[move_group.launch.py](https://github.com/frankarobotics/franka_ros2/blob/humble/franka_fr3_moveit_config/launch/move_group.launch.py) in `franka_fr3_moveit_config` will not run unless the following are declared as launch arguments and added to the `LaunchDescription`, as in `moveit.launch.py`: `namespace`, `fake_sensor_commands`, `use_fake_hardware`, `load_gripper`.

Otherwise, launching e.g. with `ros2 launch franka_fr3_moveit_config moveit.launch.py robot_ip:=dont-care` fails due to the following respective errors:

```
[ERROR] [launch_ros.actions.node]: Error while expanding or validating node name or namespace for 'package=moveit_ros_move_group, executable=move_group, name=None, namespace=<launch.substitutions.launch_configuration.LaunchConfiguration object at 0x73bb090fd930>':
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'namespace' does not exist
```

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'fake_sensor_commands' does not exist
```

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'use_fake_hardware' does not exist
```

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'load_gripper' does not exist
```

This was tested tested on ROS (2) Humble, Ubuntu 22.04 LTS.