### PR TITLE
Fix gripper node naming to use robot_type for correct topic/action prefixes

### DIFF
--- a/franka_gripper/launch/gripper.launch.py
+++ b/franka_gripper/launch/gripper.launch.py
@@ -43,7 +43,7 @@ def generate_robot_nodes(context):
         Node(
                 package='franka_gripper',
                 executable='franka_gripper_node',
-                name=['franka_gripper'],
+                name=[robot_type, '_gripper'],
                 namespace=namespace,
                 parameters=[{'robot_ip': robot_ip, 'joint_names': joint_names}, gripper_config],
                 condition=UnlessCondition(use_fake_hardware),
@@ -53,7 +53,7 @@ def generate_robot_nodes(context):
         Node(
             package='franka_gripper',
             executable='fake_gripper_state_publisher.py',
-            name=['franka_gripper'],
+            name=[robot_type, '_gripper'],
             namespace=namespace,
             parameters=[{'robot_ip': robot_ip, 'joint_names': joint_names}, gripper_config],
             condition=IfCondition(use_fake_hardware),


### PR DESCRIPTION
### Summary

This pull request fixes `franka_gripper/launch/gripper.launch.py` to follow the intended gripper node naming convention by deriving the node name from `robot_type`.

The gripper node name is now generated as `<robot_type>_gripper` instead of being hard-coded to `franka_gripper`.

### Motivation

The gripper node publishes topics and actions using private (`~`) names, so the node name determines the effective topic/action prefix. After the introduction of robot namespacing, the gripper node name was no longer aligned with `robot_type`, which caused:

* Gripper topics/actions to be published under `franka_gripper/*`
* MoveIt controller configs and joint-state aggregation to expect `fr3_gripper/*`
* Gripper joint states not being merged into `/joint_states`, causing MoveIt to report the gripper as always closed

### Changes

* Gripper node name changed from `franka_gripper` to `<robot_type>_gripper`
* Restores correct topic/action prefixes (e.g. `fr3_gripper/...` for FR3)
* Fixes MoveIt joint-state aggregation so gripper states correctly appear in `/joint_states`