### PR TITLE
docs: update clone instructions to use jazzy branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This repository contains a `.repos` file that helps you clone the required depen
    ```
 3. **Clone the Repositories:**
    ```bash
-    git clone https://github.com/frankarobotics/franka_ros2.git src
+    git clone --branch jazzy --single-branch https://github.com/frankarobotics/franka_ros2.git src
     ```
 4. **Install the dependencies**
     ```bash


### PR DESCRIPTION
The repository default branch targets Humble, but users on ROS 2 Jazzy should check out the Jazzy branch when cloning.

Update the README clone command to use `--branch jazzy` (optionally with `--single-branch`) to reduce confusion and prevent building the wrong ROS distribution branch.