### PR TITLE
feat: add Pinocchio model backend for Gazebo simulation support

### DIFF
--- a/franka_example_controllers/CMakeLists.txt
+++ b/franka_example_controllers/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library(
         src/fr3/model_example_controller.cpp
         src/motion_generator.cpp
         src/fr3/move_to_start_example_controller.cpp
+        src/robot_model_franka.cpp
+        src/robot_model_pinocchio.cpp
 )
 
 target_include_directories( ${PROJECT_NAME}

--- a/franka_example_controllers/include/franka_example_controllers/fr3/model_example_controller.hpp
+++ b/franka_example_controllers/include/franka_example_controllers/fr3/model_example_controller.hpp
@@ -19,7 +19,7 @@
 
 #include <controller_interface/controller_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include "franka_semantic_components/franka_robot_model.hpp"
+#include "franka_example_controllers/robot_model_interface.hpp"
 
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
@@ -50,7 +50,9 @@ class ModelExampleController : public controller_interface::ControllerInterface 
  private:
   std::string robot_type_;
   std::string arm_prefix_;
-  std::unique_ptr<franka_semantic_components::FrankaRobotModel> franka_robot_model_;
+  bool gazebo{false};
+  std::string robot_description_;
+  std::unique_ptr<robot_model_interface::RobotModelInterface> robot_model_;
 
   const std::string k_robot_state_interface_name{"robot_state"};
   const std::string k_robot_model_interface_name{"robot_model"};

--- a/franka_example_controllers/include/franka_example_controllers/robot_model_franka.hpp
+++ b/franka_example_controllers/include/franka_example_controllers/robot_model_franka.hpp
@@ -1,0 +1,36 @@
+#pragma once 
+
+#include "franka_example_controllers/robot_model_interface.hpp"
+#include <franka_semantic_components/franka_robot_model.hpp>
+
+namespace robot_model_interface
+{
+    class RobotModelFranka : public RobotModelInterface
+    {
+        public: 
+            RobotModelFranka(const std::string& robot_type);
+
+            void updateState(const Vector7d& q,const Vector7d& dq) override;
+
+            Eigen::Affine3d getPose(const std::string& frame_name) override;
+            Eigen::Matrix<double, 6, 7> getJacobian(const std::string& frame_name) override;
+            Eigen::Matrix<double, 7, 7> getMassMatrix() override;
+            Vector7d getCoriolis() override;
+            Vector7d getGravity() override;
+
+            std::vector<std::string> get_state_interface_names() override;
+            void assign_loaned_state_interfaces(
+                std::vector<hardware_interface::LoanedStateInterface>& state_interfaces) override;
+            void release_interfaces() override;
+
+        
+        private:
+            std::unique_ptr<franka_semantic_components::FrankaRobotModel> franka_robot_model_;
+            Vector7d q_;
+            Vector7d dq_;
+            const std::string k_robot_state_interface_name{"robot_state"};
+            const std::string k_robot_model_interface_name{"robot_model"};
+
+                franka::Frame stringToFrankaFrame(const std::string& frame_name) const;
+    };
+}

--- a/franka_example_controllers/include/franka_example_controllers/robot_model_interface.hpp
+++ b/franka_example_controllers/include/franka_example_controllers/robot_model_interface.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <hardware_interface/loaned_state_interface.hpp>
+#include <Eigen/Eigen>
+
+namespace robot_model_interface
+{
+    using Vector7d = Eigen::Matrix<double, 7, 1>;
+
+    class RobotModelInterface{
+        public: 
+            virtual ~RobotModelInterface() = default;
+            virtual void updateState(const Vector7d& q,const Vector7d& dq) = 0;
+
+            virtual Eigen::Affine3d getPose(const std::string& frame_name) = 0;
+            virtual Eigen::Matrix<double, 6, 7> getJacobian(const std::string& frame_name) = 0;
+            virtual Eigen::Matrix<double, 7, 7> getMassMatrix() = 0;
+            virtual Vector7d getCoriolis() = 0;
+            virtual Vector7d getGravity() = 0;
+
+            virtual std::vector<std::string> get_state_interface_names() = 0;
+            virtual void assign_loaned_state_interfaces(
+                std::vector<hardware_interface::LoanedStateInterface>& state_interfaces) = 0;
+            virtual void release_interfaces() = 0;
+
+    };
+}

--- a/franka_example_controllers/include/franka_example_controllers/robot_model_pinocchio.hpp
+++ b/franka_example_controllers/include/franka_example_controllers/robot_model_pinocchio.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "franka_example_controllers/robot_model_interface.hpp"
+
+#include <pinocchio/multibody/model.hpp>
+#include <pinocchio/multibody/data.hpp>
+
+#include <pinocchio/parsers/urdf.hpp>
+
+#include <pinocchio/algorithm/kinematics.hpp>
+#include <pinocchio/algorithm/jacobian.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/algorithm/compute-all-terms.hpp>
+
+namespace robot_model_interface
+{
+    class RobotModelPinocchio : public RobotModelInterface
+    {
+        public: 
+            RobotModelPinocchio(const std::string& robot_description);
+
+            void updateState(const Vector7d& q,const Vector7d& dq) override;
+
+            Eigen::Affine3d getPose(const std::string& frame_name) override;
+            Eigen::Matrix<double, 6, 7> getJacobian(const std::string& frame_name) override;
+            Eigen::Matrix<double, 7, 7> getMassMatrix() override;
+            Vector7d getCoriolis() override;
+            Vector7d getGravity() override;
+
+            std::vector<std::string> get_state_interface_names() override;
+            void assign_loaned_state_interfaces(
+                std::vector<hardware_interface::LoanedStateInterface>& state_interfaces) override;
+            void release_interfaces() override;
+
+            std::string resolveFrameName(const std::string& frame_name) const;
+
+        
+        private:
+            pinocchio::Model model_;
+            pinocchio::Data data_;
+            Vector7d q_;
+            Vector7d dq_;
+    };
+}
+
+

--- a/franka_example_controllers/src/fr3/model_example_controller.cpp
+++ b/franka_example_controllers/src/fr3/model_example_controller.cpp
@@ -11,8 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <rclcpp/wait_for_message.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include <franka_example_controllers/fr3/model_example_controller.hpp>
+#include <franka_example_controllers/robot_model_franka.hpp>
+#include <franka_example_controllers/robot_model_pinocchio.hpp>
 
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
@@ -34,6 +38,7 @@ controller_interface::CallbackReturn ModelExampleController::on_init() {
   try {
     auto_declare("robot_type", "fr3");
     auto_declare<std::string>("arm_prefix", "");
+
     if (!get_node()->get_parameter("robot_type", robot_type_)) {
       RCLCPP_FATAL(get_node()->get_logger(), "Failed to get robot_type parameter");
       get_node()->shutdown();
@@ -45,6 +50,14 @@ controller_interface::CallbackReturn ModelExampleController::on_init() {
       return CallbackReturn::ERROR;
     }
     arm_prefix_ = arm_prefix_.empty() ? "" : arm_prefix_ + "_";
+    
+    auto_declare<bool>("gazebo", false);
+    if (!get_node()->get_parameter("gazebo", gazebo)) {
+      RCLCPP_FATAL(get_node()->get_logger(), "Failed to get gazebo parameter");
+      get_node()->shutdown();
+      return CallbackReturn::ERROR;
+    }
+
   } catch (const std::exception& e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
     return CallbackReturn::ERROR;
@@ -62,18 +75,50 @@ controller_interface::InterfaceConfiguration ModelExampleController::state_inter
     const {
   controller_interface::InterfaceConfiguration state_interfaces_config;
   state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-  for (const auto& franka_robot_model_name : franka_robot_model_->get_state_interface_names()) {
-    state_interfaces_config.names.push_back(franka_robot_model_name);
+
+  if (gazebo) {
+    // In simulation, we need joint position and velocity state interfaces
+    for (int i = 1; i <= 7; i++) {
+      state_interfaces_config.names.push_back(
+          arm_prefix_ + robot_type_ + "_joint" + std::to_string(i) + "/position");
+      state_interfaces_config.names.push_back(
+          arm_prefix_ + robot_type_ + "_joint" + std::to_string(i) + "/velocity");
+    }
+  } else {
+    // On hardware, request the FCI model/state interfaces
+    for (const auto& name : robot_model_->get_state_interface_names()) {
+      state_interfaces_config.names.push_back(name);
+    }
   }
+
   return state_interfaces_config;
 }
 
 controller_interface::CallbackReturn ModelExampleController::on_configure(
     const rclcpp_lifecycle::State& /*previous_state*/) {
-  franka_robot_model_ = std::make_unique<franka_semantic_components::FrankaRobotModel>(
-      franka_semantic_components::FrankaRobotModel(
-          arm_prefix_ + robot_type_ + "/" + k_robot_model_interface_name,
-          arm_prefix_ + robot_type_ + "/" + k_robot_state_interface_name));
+
+  if (gazebo) {
+    auto temp_node = std::make_shared<rclcpp::Node>("_urdf_fetcher");
+    std_msgs::msg::String msg;
+
+    rclcpp::QoS qos(1);
+    qos.transient_local();
+
+    if (!rclcpp::wait_for_message(msg, temp_node, "/robot_description",
+            std::chrono::seconds(5), qos)) {
+        RCLCPP_ERROR(get_node()->get_logger(),
+            "Timed out waiting for /robot_description topic");
+        return CallbackReturn::ERROR;
+    }
+
+    robot_model_ = std::make_unique<robot_model_interface::RobotModelPinocchio>(msg.data);
+    RCLCPP_INFO(get_node()->get_logger(), "Using Pinocchio model backend (simulation)");
+  } 
+  else {
+    robot_model_ = std::make_unique<robot_model_interface::RobotModelFranka>(
+        arm_prefix_ + robot_type_);
+    RCLCPP_INFO(get_node()->get_logger(), "Using Franka FCI model backend (hardware)");
+  }
 
   RCLCPP_DEBUG(get_node()->get_logger(), "configured successfully");
   return CallbackReturn::SUCCESS;
@@ -81,44 +126,51 @@ controller_interface::CallbackReturn ModelExampleController::on_configure(
 
 controller_interface::CallbackReturn ModelExampleController::on_activate(
     const rclcpp_lifecycle::State& /*previous_state*/) {
-  franka_robot_model_->assign_loaned_state_interfaces(state_interfaces_);
+  robot_model_->assign_loaned_state_interfaces(state_interfaces_);
   return CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn ModelExampleController::on_deactivate(
     const rclcpp_lifecycle::State& /*previous_state*/) {
-  franka_robot_model_->release_interfaces();
+  robot_model_->release_interfaces();
   return CallbackReturn::SUCCESS;
 }
+
+
 
 controller_interface::return_type ModelExampleController::update(
     const rclcpp::Time& /*time*/,
     const rclcpp::Duration& /*period*/) {
-  std::array<double, 49> mass = franka_robot_model_->getMassMatrix();
-  std::array<double, 7> coriolis = franka_robot_model_->getCoriolisForceVector();
-  std::array<double, 7> gravity = franka_robot_model_->getGravityForceVector();
-  std::array<double, 16> pose = franka_robot_model_->getPoseMatrix(franka::Frame::kJoint4);
-  std::array<double, 42> joint4_body_jacobian_wrt_joint4 =
-      franka_robot_model_->getBodyJacobian(franka::Frame::kJoint4);
-  std::array<double, 42> endeffector_jacobian_wrt_base =
-      franka_robot_model_->getZeroJacobian(franka::Frame::kEndEffector);
+
+  if (gazebo) {
+    robot_model_interface::Vector7d q, dq;
+    for (int i = 0; i < 7; i++) {
+      q(i) = state_interfaces_[2 * i].get_value();
+      dq(i) = state_interfaces_[2 * i + 1].get_value();
+    }
+    robot_model_->updateState(q, dq);
+  }
+
+  auto mass = robot_model_->getMassMatrix();
+  auto coriolis = robot_model_->getCoriolis();
+  auto gravity = robot_model_->getGravity();
+  auto pose = robot_model_->getPose("end_effector");
+  auto jacobian = robot_model_->getJacobian("end_effector");
+
+  Eigen::IOFormat fmt(4, 0, ", ", "\n", "[", "]");
 
   RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
                        "-------------------------------------------------------------");
   RCLCPP_INFO_STREAM_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
-                              "mass :" << mass);
+                              "mass :\n" << mass.format(fmt));
   RCLCPP_INFO_STREAM_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
-                              "coriolis :" << coriolis);
+                              "coriolis :" << coriolis.transpose().format(fmt));
   RCLCPP_INFO_STREAM_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
-                              "gravity :" << gravity);
+                              "gravity :" << gravity.transpose().format(fmt));
   RCLCPP_INFO_STREAM_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
-                              "joint_pose :" << pose);
-  RCLCPP_INFO_STREAM_THROTTLE(
-      get_node()->get_logger(), *get_node()->get_clock(), 1000,
-      "joint4_body_jacobian in joint4 frame :" << joint4_body_jacobian_wrt_joint4);
-  RCLCPP_INFO_STREAM_THROTTLE(
-      get_node()->get_logger(), *get_node()->get_clock(), 1000,
-      "end_effector_jacobian in base frame :" << endeffector_jacobian_wrt_base);
+                              "ee_pose :\n" << pose.matrix().format(fmt));
+  RCLCPP_INFO_STREAM_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
+                              "ee_jacobian :\n" << jacobian.format(fmt));
   RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
                        "-------------------------------------------------------------");
 
@@ -130,4 +182,4 @@ controller_interface::return_type ModelExampleController::update(
 #include "pluginlib/class_list_macros.hpp"
 // NOLINTNEXTLINE
 PLUGINLIB_EXPORT_CLASS(franka_example_controllers::ModelExampleController,
-                       controller_interface::ControllerInterface)
+                       controller_interface::ControllerInterface)   

--- a/franka_example_controllers/src/robot_model_franka.cpp
+++ b/franka_example_controllers/src/robot_model_franka.cpp
@@ -1,0 +1,84 @@
+#include "franka_example_controllers/robot_model_franka.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include <unordered_map>
+
+
+namespace robot_model_interface
+{
+    RobotModelFranka::RobotModelFranka(const std::string& robot_type)
+    {
+        franka_robot_model_ = std::make_unique<franka_semantic_components::FrankaRobotModel>(
+            robot_type + "/" + k_robot_model_interface_name,
+            robot_type + "/" + k_robot_state_interface_name);
+    }
+
+    std::vector<std::string> RobotModelFranka::get_state_interface_names()
+    {
+        return franka_robot_model_->get_state_interface_names();
+    }
+
+    void RobotModelFranka::assign_loaned_state_interfaces(
+        std::vector<hardware_interface::LoanedStateInterface>& state_interfaces)
+    {
+        franka_robot_model_->assign_loaned_state_interfaces(state_interfaces);
+    }
+
+    void RobotModelFranka::release_interfaces()
+    {
+        franka_robot_model_->release_interfaces();
+    }
+
+    void RobotModelFranka::updateState(const Vector7d& q,const Vector7d& dq)
+    {
+        q_ = q;
+        dq_ = dq;
+    }
+
+    Eigen::Affine3d RobotModelFranka::getPose(const std::string& frame_name)
+    {
+        std::array<double, 16> pose_array = franka_robot_model_->getPoseMatrix(stringToFrankaFrame(frame_name));
+        return Eigen::Affine3d(Eigen::Matrix4d::Map(pose_array.data()));
+    }
+
+    Eigen::Matrix<double, 6, 7> RobotModelFranka::getJacobian(const std::string& frame_name)
+    {
+        std::array<double, 42> jac_array = franka_robot_model_->getZeroJacobian(stringToFrankaFrame(frame_name));
+        return Eigen::Matrix<double,6,7>(Eigen::Map<Eigen::Matrix<double,6,7>>(jac_array.data()));
+    }
+
+    Eigen::Matrix<double, 7, 7> RobotModelFranka::getMassMatrix()
+    {
+        std::array<double, 49> mass_array = franka_robot_model_->getMassMatrix();
+        return Eigen::Matrix<double,7,7>(Eigen::Map<Eigen::Matrix<double,7,7>>(mass_array.data()));
+    }
+
+    Vector7d RobotModelFranka::getCoriolis()
+    {
+        std::array<double, 7> coriolis_array = franka_robot_model_->getCoriolisForceVector();
+        return Eigen::Map<Vector7d>(coriolis_array.data());
+    }
+
+    Vector7d RobotModelFranka::getGravity()
+    {
+        std::array<double, 7> gravity_array = franka_robot_model_->getGravityForceVector();
+        return Eigen::Map<Vector7d>(gravity_array.data());
+    }
+
+    franka::Frame RobotModelFranka::stringToFrankaFrame(const std::string& frame_name) const {
+    static const std::unordered_map<std::string, franka::Frame> frame_map = {
+        {"joint1", franka::Frame::kJoint1},
+        {"joint2", franka::Frame::kJoint2},
+        {"joint3", franka::Frame::kJoint3},
+        {"joint4", franka::Frame::kJoint4},
+        {"joint5", franka::Frame::kJoint5},
+        {"joint6", franka::Frame::kJoint6},
+        {"joint7", franka::Frame::kJoint7},
+        {"flange", franka::Frame::kFlange},
+        {"end_effector", franka::Frame::kEndEffector}
+    };
+    return frame_map.at(frame_name);
+}
+
+
+}

--- a/franka_example_controllers/src/robot_model_pinocchio.cpp
+++ b/franka_example_controllers/src/robot_model_pinocchio.cpp
@@ -1,0 +1,83 @@
+#include "franka_example_controllers/robot_model_pinocchio.hpp"
+#include <unordered_map>
+
+
+namespace robot_model_interface
+{
+    RobotModelPinocchio::RobotModelPinocchio(const std::string& robot_description)
+    {
+        pinocchio::urdf::buildModelFromXML(robot_description, model_);
+        model_.gravity.linear() = Eigen::Vector3d(0, 0, -9.81);
+        data_ = pinocchio::Data(model_);
+    }
+
+    void RobotModelPinocchio::updateState(const Vector7d& q,const Vector7d& dq)
+    {
+        q_ = q;
+        dq_ = dq;
+        pinocchio::computeAllTerms(model_, data_, q_, dq_);
+        pinocchio::updateFramePlacements(model_, data_);
+    }
+
+    Eigen::Matrix<double, 7, 7> RobotModelPinocchio::getMassMatrix()
+    {
+        return Eigen::Matrix<double,7,7>(data_.M);
+    }
+
+    Vector7d RobotModelPinocchio::getCoriolis()
+    {
+        return data_.nle - data_.g;
+    }
+
+    Vector7d RobotModelPinocchio::getGravity()
+    {
+        return data_.g;
+    }
+
+    std::vector<std::string> RobotModelPinocchio::get_state_interface_names()
+    {
+        return {};
+    }
+
+    void RobotModelPinocchio::assign_loaned_state_interfaces(
+        std::vector<hardware_interface::LoanedStateInterface>& state_interfaces)
+    {
+        // No state interfaces to assign for Pinocchio model
+    }
+
+    void RobotModelPinocchio::release_interfaces()
+    {
+        // No interfaces to release for Pinocchio model
+    }
+
+    std::string RobotModelPinocchio::resolveFrameName(const std::string& frame_name) const
+    {
+        static const std::unordered_map<std::string, std::string> frame_map = {
+            {"joint1",       "fr3_link1"},
+            {"joint2",       "fr3_link2"},
+            {"joint3",       "fr3_link3"},
+            {"joint4",       "fr3_link4"},
+            {"joint5",       "fr3_link5"},
+            {"joint6",       "fr3_link6"},
+            {"joint7",       "fr3_link7"},
+            {"end_effector", "fr3_link8"},
+        };
+        auto it = frame_map.find(frame_name);
+        return (it != frame_map.end()) ? it->second : frame_name;
+    }
+
+    Eigen::Affine3d RobotModelPinocchio::getPose(const std::string& frame_name)
+    {
+        auto frame_id = model_.getFrameId(resolveFrameName(frame_name));
+        return Eigen::Affine3d(data_.oMf[frame_id].toHomogeneousMatrix());
+    }
+
+    Eigen::Matrix<double, 6, 7> RobotModelPinocchio::getJacobian(const std::string& frame_name)
+    {
+        auto frame_id = model_.getFrameId(resolveFrameName(frame_name));
+        Eigen::Matrix<double, 6, 7> J = Eigen::Matrix<double, 6, 7>::Zero();
+        pinocchio::getFrameJacobian(model_, data_, frame_id,
+            pinocchio::LOCAL_WORLD_ALIGNED, J);
+        return J;
+    }
+}

--- a/franka_gazebo_bringup/config/franka_gazebo_controllers.yaml
+++ b/franka_gazebo_bringup/config/franka_gazebo_controllers.yaml
@@ -3,6 +3,9 @@
     ros__parameters:
       update_rate: 1000  # Hz
 
+      model_example_controller:
+        type: franka_example_controllers/ModelExampleController
+
       joint_position_example_controller:
         type: franka_example_controllers/JointPositionExampleController
 
@@ -26,6 +29,13 @@
       
       swerve_drive_controller:
         type: franka_mobile/SwerveDriveController
+
+/**:
+  model_example_controller:
+    ros__parameters:
+      robot_type: "fr3"
+      gazebo: true
+
 
 /**:
   joint_velocity_example_controller:


### PR DESCRIPTION
Add a RobotModelInterface abstraction that allows model_example_controller to run in both hardware (FCI) and simulation (Pinocchio) modes , toggled via a 'gazebo' parameter in the controller YAML.

New files:
- robot_model_interface.hpp: abstract base class
- robot_model_franka.hpp/cpp: FCI backend (wraps FrankaRobotModel)
- robot_model_pinocchio.hpp/cpp: Pinocchio backend (computes from URDF)

Modified:
- model_example_controller.hpp/cpp: use RobotModelInterface polymorphism
- CMakeLists.txt: add new sources and pinocchio dependency
- franka_gazebo_controllers.yaml: add gazebo param for model_example_controller

Resolves #217