### PR TITLE
Added missing launch arguments to move_group.launch.py.

### DIFF
--- a/franka_fr3_moveit_config/launch/move_group.launch.py
+++ b/franka_fr3_moveit_config/launch/move_group.launch.py
@@ -55,6 +55,34 @@ def generate_robot_nodes(context, *args, **kwargs):
     namespace = LaunchConfiguration(namespace_parameter_name)
     arm_prefix = LaunchConfiguration(arm_prefix_parameter_name)
 
+    # Declare launch arguments used
+    robot_ip_arg = DeclareLaunchArgument(
+        robot_ip_parameter_name, 
+        description="Hostname or IP address of the robot."
+    )
+
+    load_gripper_arg = DeclareLaunchArgument(
+        load_gripper_parameter_name,
+        default_value='true',
+        description='Whether to load the gripper or not (true or false)'
+    )
+    use_fake_hardware_arg = DeclareLaunchArgument(
+        use_fake_hardware_parameter_name,
+        default_value='false',
+        description='Use fake hardware'
+    )
+    fake_sensor_commands_arg = DeclareLaunchArgument(
+        fake_sensor_commands_parameter_name,
+        default_value='false',
+        description="Fake sensor commands. Only valid when '{}' is true".format(
+            use_fake_hardware_parameter_name)
+    )
+    namespace_arg = DeclareLaunchArgument(
+        namespace_parameter_name,
+        default_value='',
+        description='Namespace for the robot.'
+    )
+
     prefix_str = arm_prefix.perform(context)
 
     franka_xacro_file = os.path.join(
@@ -175,15 +203,27 @@ def generate_robot_nodes(context, *args, **kwargs):
         ],
     )
 
-    return [run_move_group_node]
+    return [
+        robot_ip_arg,
+        load_gripper_arg,
+        use_fake_hardware_arg,
+        fake_sensor_commands_arg,
+        namespace_arg,
+        run_move_group_node,
+    ]
 
 
 def generate_launch_description():
     db_arg = DeclareLaunchArgument(
         'db', default_value='False', description='Database flag'
     )
+    arm_prefix_arg = DeclareLaunchArgument(
+        'arm_prefix',
+        default_value=''
+    )
 
     return LaunchDescription([
         db_arg,
+        arm_prefix_arg,
         OpaqueFunction(function=generate_robot_nodes)
     ])


### PR DESCRIPTION
The `move_group.launch.py` from the `franka_fr3_moveit_config` package is malformed. Several launch arguments are used but not declared. I fixed it by copying those same arguments from `moveitlaunch.py`, with the corresponding descriptions and default values. I did not add a description to the `arm_prefix` argument, however, as I found no description in the repo. Adding the default `arm_prefix` argument to an empty string allowed me to launch it successfully, however.